### PR TITLE
Fixing monitor auto-sizing platform dependency

### DIFF
--- a/Constants.py
+++ b/Constants.py
@@ -5,9 +5,17 @@ G = 0.5
 Density = 0.1
 
 # define starting window width and height
-user32 = ctypes.windll.user32
-monitor_width = user32.GetSystemMetrics(0)
-monitor_height = user32.GetSystemMetrics(1)
+try:
+    # Windows
+    import ctypes
+    dim = ctypes.cdll.user32.GetSystemMetrics
+    monitor_width, monitor_height = dim(0), dim(1)
+except:
+    # Linux
+    import subprocess, re
+    output = subprocess.Popen('xrandr | grep "\*" | cut -d" " -f4',shell=True, stdout=subprocess.PIPE).communicate()[0]
+    monitor_width, monitor_height = re.findall(r'[0-9]+',str(output))
+
 width, height = int(monitor_width * 0.6), int(monitor_height * 0.75)
 
 # Set simulation hard clock speed (fps)


### PR DESCRIPTION
This now properly detects monitor size on Ubuntu as tested in a virtual machine.